### PR TITLE
safer dll loading

### DIFF
--- a/user/Mods.lua
+++ b/user/Mods.lua
@@ -1,6 +1,6 @@
 local t7zeus = require("t7-zeus")
 
-local zeus = t7zeus.GetZeus()
+local zeus = t7zeus.zeus
 if not zeus then
     Engine.ComError(Enum.errorCode.ERROR_UI, "Could not get Zeus instance")
     return

--- a/user/Mods.lua
+++ b/user/Mods.lua
@@ -1,8 +1,6 @@
--- LuiLoad this file from CSC at the earliest point you want to load it
-EnableGlobals()
-require("t7-zeus")
+local t7zeus = require("t7-zeus")
 
-local zeus = GetZeus()
+local zeus = t7zeus.GetZeus()
 if not zeus then
     Engine.ComError(Enum.errorCode.ERROR_UI, "Could not get Zeus instance")
     return

--- a/user/t7-zeus.lua
+++ b/user/t7-zeus.lua
@@ -34,10 +34,7 @@ zeus.set_paralyzer_patch_enabled = function()
     Engine.SetDvar("paralyzer_patch_enabled", 1)
 end
 
-local GetZeus = function()
-    return zeus
-end
 
 return {
-    GetZeus = GetZeus,
+    zeus = zeus,
 }

--- a/user/t7-zeus.lua
+++ b/user/t7-zeus.lua
@@ -1,4 +1,3 @@
-EnableGlobals()
 local package = require("package")
 
 local zeus = {}
@@ -6,28 +5,39 @@ zeus.dll_name = "t7-zeus.dll"
 zeus.dll_path = ("./" .. zeus.dll_name)
 
 zeus.init = function()
+    if Engine.DvarInt(nil, "zeus_initialized") == 1 then
+        return
+    end
+
     local init = package.loadlib(zeus.dll_path, "init")
     if not init then
         Engine.ComError(Enum.errorCode.ERROR_UI, "Failed to find " .. zeus.dll_name)
         return
     end
 
-    zeus.init = init
-    zeus.init()
+    init()
+    Engine.SetDvar("zeus_initialized", 1)
 end
 
 zeus.set_paralyzer_patch_enabled = function()
-    local set_paralyzer_patch_enabled = package.loadlib(zeus.dll_path, "SetParalyzerPatchEnabled")
-    
-    if not set_paralyzer_patch_enabled then
+    if Engine.DvarInt(nil, "paralyzer_patch_enabled") == 1 then
+        return
+    end
+
+    local init = package.loadlib(zeus.dll_path, "SetParalyzerPatchEnabled")
+    if not init then
         Engine.ComError(Enum.errorCode.ERROR_UI, "SetParalyzerPatchEnabled: Failure")
         return
     end
 
-    zeus.set_paralyzer_patch_enabled = set_paralyzer_patch_enabled
-    zeus.set_paralyzer_patch_enabled()
+    init()
+    Engine.SetDvar("paralyzer_patch_enabled", 1)
 end
 
-GetZeus = function()
+local GetZeus = function()
     return zeus
 end
+
+return {
+    GetZeus = GetZeus,
+}


### PR DESCRIPTION
- load dll functions only once
- use local definitions instead of global